### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://novotecat.visualstudio.com/a2334872-b591-494d-b429-83a45aaf4313/0f7822b4-98ee-4e8d-b722-de1be4e0ccad/_apis/work/boardbadge/946df23c-051d-4f53-b14a-53495968024b)](https://novotecat.visualstudio.com/a2334872-b591-494d-b429-83a45aaf4313/_boards/board/t/0f7822b4-98ee-4e8d-b722-de1be4e0ccad/Microsoft.EpicCategory)
 # ![MudBlazor](content/MudBlazor-GitHub.png)
 # Material Design components for Blazor
 ![Azure DevOps builds (master)](https://img.shields.io/azure-devops/build/gardnet-nu/4cba3d30-858f-4653-a80d-736a8adc5daf/1/master?label=azure%20pipelines&style=flat-square)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5431](https://novotecat.visualstudio.com/a2334872-b591-494d-b429-83a45aaf4313/_workitems/edit/5431). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.